### PR TITLE
freertos/port-arm-cm33: add alternative timer support

### DIFF
--- a/FreeRTOS/Source/portable/GCC/ARM_CM33/port.c
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM33/port.c
@@ -563,9 +563,11 @@ uint32_t ulDummy;
  */
 static void prvSetupTimerInterrupt( void )
 {
-	/* Configure SysTick to interrupt at the requested rate. */
-	*(portNVIC_SYSTICK_LOAD) = ( configCPU_CLOCK_HZ / configTICK_RATE_HZ ) - 1UL;
-	*(portNVIC_SYSTICK_CTRL) = portNVIC_SYSTICK_CLK | portNVIC_SYSTICK_INT | portNVIC_SYSTICK_ENABLE;
+	if (!vPortEnableTimer()) {
+		/* Configure SysTick to interrupt at the requested rate. */
+		*(portNVIC_SYSTICK_LOAD) = ( configCPU_CLOCK_HZ / configTICK_RATE_HZ ) - 1UL;
+		*(portNVIC_SYSTICK_CTRL) = portNVIC_SYSTICK_CLK | portNVIC_SYSTICK_INT | portNVIC_SYSTICK_ENABLE;
+	}
 }
 /*-----------------------------------------------------------*/
 

--- a/FreeRTOS/Source/portable/GCC/ARM_CM33/portmacro.h
+++ b/FreeRTOS/Source/portable/GCC/ARM_CM33/portmacro.h
@@ -242,6 +242,10 @@ extern uintptr_t ulPortGetStackedLR( StackType_t *pxTopOfStack );
 // fell behind and missed some tick interrupts (i.e. while running in an emulator).
 extern bool vPortCorrectTicks(void);
 
+// Platform override mechanism to use an alternate (non-SysTick) timer
+// source.
+extern bool vPortEnableTimer(void);
+
 //! The indexes of the registers as stored on a task's stack by FreeRTOS
 typedef enum {
 	portTASK_REG_INDEX_CONTROL = 0,


### PR DESCRIPTION
Refer CM4F, add a alternative timer to instead arm cm33 systick.